### PR TITLE
increased haiku / deploy timeouts

### DIFF
--- a/around_the_grounds/temporal/workflows.py
+++ b/around_the_grounds/temporal/workflows.py
@@ -80,7 +80,13 @@ class FoodTruckWorkflow:
                 web_data = await workflow.execute_activity(
                     deploy_activities.generate_web_data,
                     {"events": events, "errors": errors},
-                    schedule_to_close_timeout=timedelta(seconds=30),
+                    # generate_web_data includes haiku generation, which calls
+                    # the Anthropic API and can be slow on self-hosted network
+                    # paths. Cap any single attempt at 90s so a hung call can't
+                    # eat the whole budget; give the activity up to 3 minutes
+                    # total across retries to accommodate transient SDK issues.
+                    start_to_close_timeout=timedelta(seconds=90),
+                    schedule_to_close_timeout=timedelta(seconds=180),
                 )
 
                 deployed = await workflow.execute_activity(

--- a/around_the_grounds/utils/haiku_generator.py
+++ b/around_the_grounds/utils/haiku_generator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import anthropic
+import httpx
 
 from ..models import Event
 
@@ -89,9 +90,18 @@ class HaikuGenerator:
         prompt_template: Optional[str] = None,
     ):
         """Initialize haiku generator with Anthropic API client."""
+        # The anthropic SDK defaults to httpx.Timeout(600.0, connect=5.0). On
+        # self-hosted network paths with slow DNS resolution (e.g. a NAS where
+        # getaddrinfo AF_UNSPEC runs IPv4 + IPv6 sequentially and each takes
+        # ~5s), the 5s connect ceiling fires during DNS before TCP even starts,
+        # causing every request to fail with APIConnectionError. Bump connect
+        # to 30s (plenty of headroom for slow DNS + TCP + TLS) and total to
+        # 60s (covers the full roundtrip + generation, typically 5–10s).
         self.client = anthropic.AsyncAnthropic(
-            api_key=api_key
-        )  # Uses ANTHROPIC_API_KEY env var if None
+            api_key=api_key,  # Uses ANTHROPIC_API_KEY env var if None
+            timeout=httpx.Timeout(60.0, connect=30.0),
+            max_retries=2,
+        )
         self.logger = logging.getLogger(__name__)
         self.prompt_template = (
             prompt_template


### PR DESCRIPTION
# fix: raise anthropic + Temporal timeouts for slow self-hosted paths

Post-merge fix for haiku generation failing on self-hosted deploy targets with slow DNS resolution.

Note: The Anthropic API calling code shouldn't have its own internal retries (should be dedicated Temporal activites). This is a future change to make.

**Root cause:**
- Anthropic SDK default is `httpx.Timeout(600.0, connect=5.0)`
- On self-hosted network paths where `getaddrinfo` AF_UNSPEC (Python's default) takes ~10s (IPv4 + IPv6 resolved sequentially at ~5s each), the 5s connect ceiling fires during DNS before TCP even starts
- Every request raises `APIConnectionError`, the whole `generate_web_data` activity fails, the workflow aborts

**Changes:**
- `utils/haiku_generator.py` — wrap `AsyncAnthropic` with `httpx.Timeout(60.0, connect=30.0)` + explicit `max_retries=2` (3× headroom over observed 10s DNS)
- `temporal/workflows.py` — `generate_web_data` activity now uses `start_to_close_timeout=90s` (per-attempt cap) + `schedule_to_close_timeout=180s` (was 30s, full retry budget)

**Verified:**
- 499 tests still passing (mocks bypass the real client)
- Local end-to-end run: real weather fetch + real Anthropic call produced a weather-grounded haiku in 2.84s