### PR TITLE
fix: replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/around_the_grounds/parsers/generic/ajax.py
+++ b/around_the_grounds/parsers/generic/ajax.py
@@ -7,7 +7,7 @@ api_url is not provided.
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 import aiohttp
@@ -166,9 +166,7 @@ class AjaxParser(BaseParser):
         self, params: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Replace {{today_iso}} and {{end_date_iso}} with actual UTC dates."""
-        from datetime import timedelta
-
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         end = now + timedelta(days=7)
         today_iso = now.strftime("%Y-%m-%dT00:00:00.000Z")
         end_iso = end.strftime("%Y-%m-%dT23:59:59.999Z")


### PR DESCRIPTION
## Summary
- Replaces `datetime.utcnow()` (deprecated since Python 3.12) in `around_the_grounds/parsers/generic/ajax.py` with `datetime.now(timezone.utc)`
- Moves `timedelta` and `timezone` to the top-level `from datetime import ...` line, removing the local import that was inside `_resolve_date_placeholders`
- No behavior change: `.strftime()` calls produce the same UTC ISO string output; the datetime is now timezone-aware instead of naive

## Test plan
- [ ] Verified `datetime.now(timezone.utc)` produces correct UTC ISO strings matching the previous format
- [ ] 279 non-async unit/integration tests pass with no regressions (async test failures are a pre-existing pytest-asyncio 1.0.0 version mismatch in the worktree venv, unrelated to this change)
- [ ] Grep confirms no other `utcnow()` calls remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)