### PR TITLE
fix: mask access token in git error logs to prevent credential leak

### DIFF
--- a/around_the_grounds/main.py
+++ b/around_the_grounds/main.py
@@ -24,6 +24,7 @@ from .config.loader import load_all_sites, load_site_config, load_site_from_path
 from .config.settings import get_git_repository_url
 from .models import Venue, Event, SiteConfig
 from .scrapers.coordinator import ScraperCoordinator, ScrapingError
+from .utils.github_auth import _sanitize_url
 from .utils.haiku_generator import HaikuGenerator
 from .utils.timezone_utils import (
     format_time_with_site_timezone,
@@ -422,8 +423,8 @@ def _deploy_with_github_auth(
             return True
 
     except subprocess.CalledProcessError as e:
-        error_msg = e.stderr.decode("utf-8") if e.stderr else str(e)
-        print(f"❌ Git operation failed: {error_msg}")
+        raw = e.stderr.decode("utf-8") if e.stderr else str(e)
+        print(f"❌ Git operation failed: {_sanitize_url(raw)}")
         return False
     except Exception as e:
         print(f"❌ Error during deployment: {e}")

--- a/around_the_grounds/utils/github_auth.py
+++ b/around_the_grounds/utils/github_auth.py
@@ -3,6 +3,7 @@
 import base64
 import logging
 import os
+import re
 import time
 from typing import Tuple
 
@@ -10,6 +11,11 @@ import jwt
 import requests  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_url(url: str) -> str:
+    """Replace token in authenticated git URL with '***' for safe logging."""
+    return re.sub(r"x-access-token:[^@]+@", "x-access-token:***@", url)
 
 
 class GitHubAppAuth:
@@ -135,8 +141,9 @@ class GitHubAppAuth:
             logger.info("Git authentication configured successfully")
 
         except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to configure git authentication: {e}")
-            raise ValueError(f"Failed to configure git authentication: {e}")
+            msg = _sanitize_url(str(e))
+            logger.error("Failed to configure git authentication: %s", msg)
+            raise ValueError(f"Failed to configure git authentication: {msg}")
 
 
 def setup_github_auth(repository_url: str) -> None:


### PR DESCRIPTION
## Summary
- Add `_sanitize_url()` helper in `utils/github_auth.py` that replaces `x-access-token:TOKEN@` with `x-access-token:***@`
- Apply sanitization in `github_auth.py:configure_git_auth()` error handler so raw `CalledProcessError` strings don't expose the token
- Apply sanitization in `main.py:_deploy_with_github_auth()` stderr decode path

## Test plan
- [ ] `uv run python -m pytest` — existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)