### PR TITLE
fix: log haiku generation failures instead of silently swallowing them

### DIFF
--- a/around_the_grounds/main.py
+++ b/around_the_grounds/main.py
@@ -32,6 +32,9 @@ from .utils.timezone_utils import (
     now_in_site_timezone_naive,
 )
 
+logger = logging.getLogger(__name__)
+
+
 def format_events_output(
     events: List[Event], errors: Optional[List[ScrapingError]] = None
 ) -> str:
@@ -110,8 +113,6 @@ async def _generate_description_for_today(
     if not site.generate_description:
         return None
 
-    logger = logging.getLogger(__name__)
-
     if not os.environ.get("ANTHROPIC_API_KEY"):
         logger.warning(
             "ANTHROPIC_API_KEY not set — skipping haiku generation. "
@@ -137,9 +138,7 @@ async def _generate_description_for_today(
         return haiku
 
     except Exception as e:
-        logger.warning(
-            f"Failed to generate description, continuing without it: {e}"
-        )
+        logger.warning("Haiku generation failed: %s", e, exc_info=True)
         return None
 
 
@@ -238,8 +237,8 @@ async def generate_web_data(
                 description = await haiku_generator.generate_haiku(
                     today_local, today_events, max_retries=2
                 )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Haiku generation failed: %s", e, exc_info=True)
 
     return {
         "events": web_events,


### PR DESCRIPTION
## Summary

- Replaces `except Exception: pass` in the legacy haiku path (`generate_web_data`) with `logger.warning("Haiku generation failed: %s", e, exc_info=True)` so API errors, timeouts, and other failures are visible in production logs
- Promotes the local `logger = logging.getLogger(__name__)` inside `_generate_description_for_today` to module level, consistent with every other module in the codebase
- Applies the same consistent `%s`-style warning with `exc_info=True` to the exception handler in `_generate_description_for_today`, which previously used an f-string and omitted the traceback

## Test plan

- [ ] All 279 synchronous tests pass (`python3 -m pytest -q -p no:asyncio --ignore=tests/temporal`)
- [ ] Async test failures are pre-existing environment issues (pytest-asyncio version mismatch) unrelated to this change — confirmed identical failures on unmodified `main` branch code
- [ ] Manually verify: when `ANTHROPIC_API_KEY` is missing or the API is unreachable, the warning log line appears with full traceback instead of the failure being silently discarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)