### PR TITLE
fix: replace nested asyncio antipattern in urban_family.py

### DIFF
--- a/around_the_grounds/parsers/urban_family.py
+++ b/around_the_grounds/parsers/urban_family.py
@@ -397,7 +397,7 @@ class UrbanFamilyParser(BaseParser):
                     "Received JSON data with "
                     f"{len(data) if isinstance(data, list) else 'unknown'} items"
                 )
-                events = self._parse_json_data(data)
+                events = await self._parse_json_data(data)
                 valid_events = self.filter_valid_events(events)
                 self.logger.info(
                     f"Parsed {len(valid_events)} valid events from {len(events)} total"
@@ -411,53 +411,41 @@ class UrbanFamilyParser(BaseParser):
                 raise
             raise ValueError(f"Failed to parse Urban Family API: {str(e)}")
 
-    def _parse_json_data(self, data: Any) -> List[Event]:
+    async def _parse_json_data(self, data: Any) -> List[Event]:
         """
         Parse JSON data from the Urban Family API into Event objects.
         """
-        events = []
-
         try:
-            # Handle different possible JSON structures
+            # Collect items from the various possible JSON shapes
             if isinstance(data, list):
-                # If data is a list of events
-                for item in data:
-                    event = self._parse_event_item(item)
-                    if event:
-                        events.append(event)
+                items: List[Any] = data
             elif isinstance(data, dict):
-                # If data is a dict, look for events in common keys
                 if "events" in data:
-                    for item in data["events"]:
-                        event = self._parse_event_item(item)
-                        if event:
-                            events.append(event)
+                    items = data["events"]
                 elif "data" in data:
-                    for item in data["data"]:
-                        event = self._parse_event_item(item)
-                        if event:
-                            events.append(event)
+                    items = data["data"]
                 else:
-                    # Try to parse the entire dict as a single event
-                    event = self._parse_event_item(data)
-                    if event:
-                        events.append(event)
+                    items = [data]
             else:
                 self.logger.warning(f"Unexpected data type: {type(data)}")
+                return []
+
+            results = await asyncio.gather(
+                *[self._parse_event_item(item) for item in items]
+            )
+            return [e for e in results if e is not None]
 
         except Exception as e:
             self.logger.error(f"Error parsing JSON data: {str(e)}")
             raise ValueError(f"Failed to parse event data: {str(e)}")
 
-        return events
-
-    def _parse_event_item(self, item: Dict[str, Any]) -> Optional[Event]:
+    async def _parse_event_item(self, item: Dict[str, Any]) -> Optional[Event]:
         """
         Parse a single event item from the JSON data.
         """
         try:
             # Extract food truck name from various possible fields
-            food_truck_name, ai_generated = self._extract_food_truck_name(item)
+            food_truck_name, ai_generated = await self._extract_food_truck_name(item)
             if not food_truck_name:
                 # For Urban Family, many events don't have specific vendor names yet
                 # Return "TBD" instead of skipping to show the time slot is reserved
@@ -491,7 +479,7 @@ class UrbanFamilyParser(BaseParser):
             self.logger.debug(f"Error parsing event item: {str(e)}, item: {item}")
             return None
 
-    def _extract_food_truck_name(
+    async def _extract_food_truck_name(
         self, item: Dict[str, Any]
     ) -> Tuple[Optional[str], bool]:
         """
@@ -522,29 +510,13 @@ class UrbanFamilyParser(BaseParser):
                         f"Cached vision result for {image_url} was None, retrying vision analysis"
                     )
                     # Don't return early - retry vision analysis for failed cache entries
-                    # This helps recover from temporary failures
 
             self.logger.debug(f"Attempting vision analysis for image: {image_url}")
 
-            # Use asyncio to run the async vision analysis
             try:
-                # Try to get the running event loop first
-                try:
-                    asyncio.get_running_loop()
-                    # If there's already a running loop, we need to use a different approach
-                    import concurrent.futures
-
-                    with concurrent.futures.ThreadPoolExecutor() as executor:
-                        future = executor.submit(
-                            asyncio.run,
-                            self.vision_analyzer.analyze_food_truck_image(image_url),
-                        )
-                        vision_name = future.result(timeout=30)
-                except RuntimeError:
-                    # No running event loop, safe to create a new one
-                    vision_name = asyncio.run(
-                        self.vision_analyzer.analyze_food_truck_image(image_url)
-                    )
+                vision_name = await self.vision_analyzer.analyze_food_truck_image(
+                    image_url
+                )
 
                 # Cache the result (even if None)
                 self._vision_cache[image_url] = vision_name
@@ -560,8 +532,6 @@ class UrbanFamilyParser(BaseParser):
                     )
             except Exception as e:
                 self.logger.warning(f"Vision analysis failed for {image_url}: {str(e)}")
-                # Don't cache failures permanently - allow retries on subsequent runs
-                # Only cache successful results or after multiple failures
 
         # Return None if no valid name found
         return None, False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -p asyncio"
 markers = [
     "unit: Unit tests",
     "integration: Integration tests", 

--- a/tests/integration/test_vision_integration.py
+++ b/tests/integration/test_vision_integration.py
@@ -31,7 +31,7 @@ class TestVisionIntegration:
             "applicantVendors": [],
         }
 
-        result, ai_generated = parser._extract_food_truck_name(test_item)
+        result, ai_generated = await parser._extract_food_truck_name(test_item)
         assert result == "Georgia's"
         assert ai_generated
         mock_vision.assert_called_once_with("https://example.com/logo_main_updated.jpg")
@@ -53,7 +53,7 @@ class TestVisionIntegration:
             "applicantVendors": [],
         }
 
-        result, ai_generated = parser._extract_food_truck_name(test_item)
+        result, ai_generated = await parser._extract_food_truck_name(test_item)
         assert result == "Marination"
         assert not ai_generated
         # Vision analysis should not be called when text extraction succeeds
@@ -75,7 +75,7 @@ class TestVisionIntegration:
             "applicantVendors": [],
         }
 
-        result, ai_generated = parser._extract_food_truck_name(test_item)
+        result, ai_generated = await parser._extract_food_truck_name(test_item)
         assert result is None
         assert not ai_generated
         mock_vision.assert_called_once_with("https://example.com/logo_main_updated.jpg")
@@ -90,7 +90,7 @@ class TestVisionIntegration:
         # Test item with no image - should not call vision analysis
         test_item = {"eventTitle": "FOOD TRUCK", "applicantVendors": []}
 
-        result, ai_generated = parser._extract_food_truck_name(test_item)
+        result, ai_generated = await parser._extract_food_truck_name(test_item)
         assert result is None
         assert not ai_generated
         # Vision analysis should not be called when no image is available
@@ -113,7 +113,7 @@ class TestVisionIntegration:
         }
 
         # Should handle exception gracefully and fall back to TBD
-        result, ai_generated = parser._extract_food_truck_name(test_item)
+        result, ai_generated = await parser._extract_food_truck_name(test_item)
         assert result is None
         assert not ai_generated
         mock_vision.assert_called_once_with("https://example.com/logo_main_updated.jpg")
@@ -135,7 +135,7 @@ class TestVisionIntegration:
             "applicantVendors": [],
         }
 
-        result, ai_generated = parser._extract_food_truck_name(test_item)
+        result, ai_generated = await parser._extract_food_truck_name(test_item)
         assert result == "Vision Extracted Name"
         assert ai_generated
         mock_vision.assert_called_once_with("https://example.com/logo_updated_main.jpg")
@@ -157,7 +157,7 @@ class TestVisionIntegration:
             "applicantVendors": [],
         }
 
-        result, ai_generated = parser._extract_food_truck_name(test_item)
+        result, ai_generated = await parser._extract_food_truck_name(test_item)
         # Should extract from filename, not use vision
         assert result == "Georgias Greek Food"
         assert not ai_generated

--- a/tests/parsers/test_urban_family.py
+++ b/tests/parsers/test_urban_family.py
@@ -410,29 +410,31 @@ class TestUrbanFamilyParser:
         assert event_by_date[11].title == "Good Eats"
         assert event_by_date[11].date == datetime(2025, 7, 11)
 
-    def test_extract_food_truck_name_from_title(
+    @pytest.mark.asyncio
+    async def test_extract_food_truck_name_from_title(
         self, parser: UrbanFamilyParser
     ) -> None:
         """Test food truck name extraction from event title."""
         # Test explicit name in title
         item1 = {"eventTitle": "FOOD TRUCK - Awesome Tacos"}
-        result, ai_generated = parser._extract_food_truck_name(item1)
+        result, ai_generated = await parser._extract_food_truck_name(item1)
         assert result == "Awesome Tacos"
         assert not ai_generated
 
         # Test title that's not just "FOOD TRUCK"
         item2 = {"eventTitle": "Special Event - Pizza Night"}
-        result, ai_generated = parser._extract_food_truck_name(item2)
+        result, ai_generated = await parser._extract_food_truck_name(item2)
         assert result == "Special Event - Pizza Night"
         assert not ai_generated
 
         # Test generic "FOOD TRUCK" title (should return None for this test)
         item3 = {"eventTitle": "FOOD TRUCK"}
-        result, ai_generated = parser._extract_food_truck_name(item3)
+        result, ai_generated = await parser._extract_food_truck_name(item3)
         assert result is None
         assert not ai_generated
 
-    def test_extract_food_truck_name_from_image_url(
+    @pytest.mark.asyncio
+    async def test_extract_food_truck_name_from_image_url(
         self, parser: UrbanFamilyParser
     ) -> None:
         """Test food truck name extraction from image URL."""
@@ -440,11 +442,12 @@ class TestUrbanFamilyParser:
             "eventTitle": "FOOD TRUCK",
             "eventImage": "https://hivey-1.s3.us-east-1.amazonaws.com/uploads/awesome_tacos_logo.jpg",
         }
-        result, ai_generated = parser._extract_food_truck_name(item)
+        result, ai_generated = await parser._extract_food_truck_name(item)
         assert result == "Awesome Tacos"  # Improved logic removes "Logo" suffix
         assert not ai_generated
 
-    def test_extract_food_truck_name_no_valid_name(
+    @pytest.mark.asyncio
+    async def test_extract_food_truck_name_no_valid_name(
         self, parser: UrbanFamilyParser
     ) -> None:
         """Test when no valid food truck name can be extracted."""
@@ -452,7 +455,7 @@ class TestUrbanFamilyParser:
             "eventTitle": "FOOD TRUCK",
             "eventImage": "https://example.com/logo.png",
         }
-        result, ai_generated = parser._extract_food_truck_name(item)
+        result, ai_generated = await parser._extract_food_truck_name(item)
         assert result is None
         assert not ai_generated
 
@@ -561,7 +564,8 @@ class TestUrbanFamilyParser:
         assert start_time is None
         assert end_time is None
 
-    def test_parse_json_data_dict_format(self, parser: UrbanFamilyParser) -> None:
+    @pytest.mark.asyncio
+    async def test_parse_json_data_dict_format(self, parser: UrbanFamilyParser) -> None:
         """Test parsing JSON data in dict format with 'events' key."""
         data = {
             "events": [
@@ -579,18 +583,21 @@ class TestUrbanFamilyParser:
             ]
         }
 
-        events = parser._parse_json_data(data)
+        events = await parser._parse_json_data(data)
         assert len(events) == 1
         assert events[0].title == "Test Truck"
 
-    def test_parse_json_data_invalid_structure(self, parser: UrbanFamilyParser) -> None:
+    @pytest.mark.asyncio
+    async def test_parse_json_data_invalid_structure(
+        self, parser: UrbanFamilyParser
+    ) -> None:
         """Test parsing invalid JSON data structure."""
         # String data should be handled gracefully (returns empty list)
-        events = parser._parse_json_data("invalid data")
+        events = await parser._parse_json_data("invalid data")
         assert events == []
 
         # Number data should be handled gracefully (returns empty list)
-        events = parser._parse_json_data(123)
+        events = await parser._parse_json_data(123)
         assert events == []
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Converts `_extract_food_truck_name`, `_parse_event_item`, and `_parse_json_data` from sync methods (with `ThreadPoolExecutor` + `asyncio.run()` workaround) to native `async def` + `await`
- `_parse_json_data` now fans out all event items concurrently via `asyncio.gather` instead of processing them sequentially in a loop
- Adds `-p asyncio` to pytest `addopts` so `pytest-asyncio` loads reliably in this environment
- Updates all affected tests in `tests/parsers/test_urban_family.py` and `tests/integration/test_vision_integration.py` to use `async def` + `await`

## Test plan

- [x] `uv run python -m pytest tests/parsers/test_urban_family.py` — 22 passed
- [x] `uv run python -m pytest tests/integration/test_vision_integration.py` — 8 passed
- [x] `uv run python -m pytest` — 490 passed, 1 skipped (full suite)
- [ ] `uv run around-the-grounds --preview` — live scrape with Urban Family parser

Closes part of issue #10 (fix #3: nested asyncio antipattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)