### PR TITLE
fix: template path traversal guard in deploy and preview

### DIFF
--- a/around_the_grounds/main.py
+++ b/around_the_grounds/main.py
@@ -296,6 +296,26 @@ async def deploy_to_web(
         return False
 
 
+def _resolve_template_dir(template_dir_name: str) -> Path:
+    """Return the template directory path for *template_dir_name*.
+
+    Raises ValueError if the name would escape ``public_templates/`` via path
+    traversal (e.g. ``../../etc``).  Falls back to the legacy ``public_template``
+    directory when the per-template subdirectory does not exist.
+    """
+    cwd = Path.cwd()
+    multi = cwd / "public_templates" / template_dir_name
+    # Validate before the exists() check so a crafted name is rejected even
+    # when the traversal target does not exist on disk.
+    templates_root = (cwd / "public_templates").resolve()
+    resolved = multi.resolve()
+    if not str(resolved).startswith(str(templates_root) + os.sep) and resolved != templates_root:
+        raise ValueError(
+            f"Template path escapes public_templates/: {template_dir_name!r}"
+        )
+    return multi if multi.exists() else cwd / "public_template"
+
+
 def _deploy_with_github_auth(
     web_data: dict,
     repository_url: str,
@@ -321,10 +341,7 @@ def _deploy_with_github_auth(
     try:
         print("🔐 Using GitHub App authentication for deployment...")
 
-        # Resolve template directory — try multi-template path first, fall back to legacy.
-        public_templates_dir = Path.cwd() / "public_templates" / template_dir_name
-        if not public_templates_dir.exists():
-            public_templates_dir = Path.cwd() / "public_template"
+        public_templates_dir = _resolve_template_dir(template_dir_name)
 
         # Mint GitHub App access token once and build the authenticated URL upfront
         # so it can be used for both clone (subdir mode) and push (both modes).
@@ -449,9 +466,7 @@ async def preview_locally(
         else:
             template_dir_name = "food-trucks"
 
-        public_templates_dir = Path.cwd() / "public_templates" / template_dir_name
-        if not public_templates_dir.exists():
-            public_templates_dir = Path.cwd() / "public_template"
+        public_templates_dir = _resolve_template_dir(template_dir_name)
 
         local_public_dir = Path.cwd() / "public"
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,6 +1,8 @@
 """Integration tests for CLI functionality."""
 
+import asyncio
 import json
+import os
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -9,8 +11,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from around_the_grounds.main import format_events_output, main
+from around_the_grounds.main import (
+    _deploy_with_github_auth,
+    format_events_output,
+    main,
+    preview_locally,
+)
 from around_the_grounds.models import Event, Venue
+from around_the_grounds.models.site import SiteConfig
 from around_the_grounds.scrapers.coordinator import ScrapingError
 
 
@@ -302,3 +310,82 @@ class TestCLI:
             # Note: This would require actual parser implementations
             # that can handle the test URLs from the config
             # For now, this documents the integration test structure
+
+
+class TestTemplatePathTraversalGuard:
+    """Tests for the path traversal guard in _deploy_with_github_auth and preview_locally."""
+
+    def test_deploy_rejects_traversal_template(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        """_deploy_with_github_auth returns False and prints an error for traversal names."""
+        (tmp_path / "public_templates").mkdir()
+
+        original_cwd = Path.cwd()
+        try:
+            os.chdir(tmp_path)
+            result = _deploy_with_github_auth(
+                web_data={},
+                repository_url="https://github.com/user/repo.git",
+                template_dir_name="../escape_target",
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Template path escapes" in captured.out
+
+    def test_deploy_accepts_valid_template(self, tmp_path: Path, capsys: Any) -> None:
+        """_deploy_with_github_auth does not trigger the traversal guard for a valid name."""
+        (tmp_path / "public_templates" / "food-trucks").mkdir(parents=True)
+
+        original_cwd = Path.cwd()
+        try:
+            os.chdir(tmp_path)
+            # GitHub auth will fail (no credentials), but the guard must not fire.
+            _deploy_with_github_auth(
+                web_data={},
+                repository_url="https://github.com/user/repo.git",
+                template_dir_name="food-trucks",
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        captured = capsys.readouterr()
+        assert "Template path escapes" not in captured.out
+
+    def test_preview_rejects_traversal_template(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        """preview_locally returns False when the template name escapes public_templates/."""
+        (tmp_path / "public_templates").mkdir()
+
+        site = SiteConfig(
+            key="test",
+            name="Test",
+            template="../escape_preview",
+            timezone="America/New_York",
+            venues=[],
+        )
+
+        original_cwd = Path.cwd()
+        try:
+            os.chdir(tmp_path)
+
+            async def _run() -> bool:
+                with patch(
+                    "around_the_grounds.main.generate_web_data",
+                    new_callable=AsyncMock,
+                ) as mock_gen:
+                    mock_gen.return_value = {}
+                    return await preview_locally(events=[], site=site)
+
+            result = asyncio.run(_run())
+        finally:
+            os.chdir(original_cwd)
+
+        # ValueError is caught inside preview_locally; it returns False.
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Template path escapes" in captured.out


### PR DESCRIPTION
## Summary

- Extracts `_resolve_template_dir(template_dir_name)` as a shared helper that validates the template name from site config cannot escape `public_templates/` via path traversal (e.g. `../../etc`)
- The check runs before `Path.exists()` so crafted names are rejected even when the traversal target does not exist on disk
- Both `_deploy_with_github_auth` and `preview_locally` now call this helper — eliminates the previously duplicated resolution + fallback logic
- Falls back to legacy `public_template/` directory (hardcoded, safe) when the per-template subdirectory does not exist

## Test plan

- [ ] `test_deploy_rejects_traversal_template` — `_deploy_with_github_auth` returns `False` and prints traversal error for `../escape_target`
- [ ] `test_deploy_accepts_valid_template` — valid template name (`food-trucks`) does not trigger the guard
- [ ] `test_preview_rejects_traversal_template` — `preview_locally` returns `False` and prints traversal error for `../escape_preview`
- [ ] Full test suite: `uv run python -m pytest` — 293 passing, 200 pre-existing async failures unrelated to this change (asyncio_mode config incompatibility in this worktree environment), 0 new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)