### PR TITLE
Guard Claude workflows against running in forks/mirrors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   claude-review:
+    # Guard against forks/mirrors (e.g. jredding's around-the-grounds-brooklyn)
+    # where CLAUDE_CODE_OAUTH_TOKEN is not configured.
+    if: github.repository == 'steveandroulakis/around-the-grounds'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,13 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.repository == 'steveandroulakis/around-the-grounds' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add `github.repository == 'steveandroulakis/around-the-grounds'` guard to `claude-code-review.yml` so the review job skips in any fork/mirror
- Combine the same guard with the existing `@claude` mention filter in `claude.yml`
- Fixes failing workflow runs in jredding's `around-the-grounds-brooklyn` mirror, where `CLAUDE_CODE_OAUTH_TOKEN` is not configured

## Test plan
- [ ] Merge and confirm workflow still triggers on PRs in this repo
- [ ] Confirm jredding's mirror no longer shows failed Claude workflow runs on new PRs / @claude mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)