### PR TITLE
Low touch -  Skip deploy commits when events haven't changed

### DIFF
--- a/around_the_grounds/main.py
+++ b/around_the_grounds/main.py
@@ -394,6 +394,25 @@ def _deploy_with_github_auth(
             shutil.copytree(public_templates_dir, target_public_dir, dirs_exist_ok=True)
 
             json_path = target_public_dir / "data.json"
+
+            # If the prior data.json has the same events, carry its volatile
+            # fields (`updated`, `haiku`) forward so the file stays
+            # byte-identical and the no-op short-circuit below skips the
+            # commit. Without this, `updated=datetime.now()` and the
+            # AI-generated haiku change every run and force a commit even
+            # when nothing meaningful changed.
+            if json_path.exists():
+                try:
+                    with open(json_path) as f:
+                        prior = json.load(f)
+                    if prior.get("events") == web_data.get("events"):
+                        if "updated" in prior:
+                            web_data["updated"] = prior["updated"]
+                        if "haiku" in prior:
+                            web_data["haiku"] = prior["haiku"]
+                except (json.JSONDecodeError, OSError):
+                    pass
+
             with open(json_path, "w") as f:
                 json.dump(web_data, f, indent=2)
 


### PR DESCRIPTION
2 PRs - same goal. One simple, one mildly more complex, but architecturally preferred. 
**Goal**: If after a parse the event data is the same do not regenerate or deploy the data.json file (i.e. no need to do so). 

## Summary                                                                                                                                                          
  The existing `git diff --staged --quiet` short-circuit in subdir mode (`main.py:410-416`) never fires because `data.json` always differs across runs:               
  - `updated`: `datetime.now(timezone.utc).isoformat()` — different every run                                                                                         
  - `haiku`: AI-generated at `temperature=0.85` — different every run                                                                                               
                                                                                                                                                                      
  Every parsing produces a new file even if nothing of substance has changed
                                                                                                                                                                      
  This change carries those two volatile fields forward from the prior `data.json` when the `events` array is identical to the new one. The file then stays           
  byte-identical and the existing skip catches it cleanly. No new diff logic, no new code paths.                                                                      
                                                                                                                                                                      
  ## Behavior                                                                                                                                                         
  | Run-over-run change | Result |                                                                                                                                    
  |---|---|                                                                                                                                                           
  | Events array changed | Commit + push (as before) |                                                                                                                
  | Events identical, only `updated`/`haiku` differ | **No commit, no push** |  (Ideally this check is                                                                                         
  | Events identical, but `index.html` was edited (template change) | Commit + push (template diff still picked up by `git diff`) |                                   
  | Events identical, but `errors` differ (rare — venue failures usually drop events too) | Commit + push (errors aren't carried forward) |                           
  | Prior `data.json` missing or malformed | Falls through, writes fresh — no regression |                                                                            
                                                                                                                                                                      
  ## Test plan                                                                                                                                                        
  - [x] `pytest tests/integration/test_cli.py` — 19 tests pass                                                                                                        
  - [ ] Smoke test: run `--deploy` twice in quick succession against `lobakgo-to`; verify second run reports "No changes to deploy" and produces no commit            
  - [ ] Confirm template edits still trigger a deploy on the next run  