### PR TITLE
Skip haiku regeneration on no-op deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 .DS_Store
 .env
 public/
+.cache/
 
 # Added by Spec Kitty CLI (auto-managed)
 .claude/

--- a/around_the_grounds/main.py
+++ b/around_the_grounds/main.py
@@ -223,27 +223,48 @@ async def generate_web_data(
 
     unique_error_messages = list(dict.fromkeys(error_messages or []))
 
-    # Generate description if site opts in
-    description = None
-    if site:
-        description = await _generate_description_for_today(events, site)
-    else:
-        # Legacy path: try to generate haiku without site context
+    # Reuse the prior run's haiku/timestamp when the event set is unchanged.
+    # Skips an Anthropic API call on stable days and keeps data.json byte-
+    # identical so the deploy's no-op short-circuit can skip the commit.
+    # Only the site-aware path caches; the legacy no-site path stays pure
+    # so unit tests don't accumulate hidden state.
+    cache_path: Optional[Path] = (
+        Path.cwd() / ".cache" / "around-the-grounds" / f"{site_key}.json"
+        if site is not None
+        else None
+    )
+    description: Optional[str] = None
+    updated: Optional[str] = None
+    if cache_path is not None and cache_path.exists():
         try:
-            today_local = now_in_site_timezone_naive(site_tz)
-            today = today_local.date()
-            today_events = [e for e in events if e.date.date() == today]
-            if today_events:
-                haiku_generator = HaikuGenerator()
-                description = await haiku_generator.generate_haiku(
-                    today_local, today_events, max_retries=2
-                )
-        except Exception as e:
-            logger.warning("Haiku generation failed: %s", e, exc_info=True)
+            prior = json.loads(cache_path.read_text())
+            if prior.get("events") == web_events:
+                description = prior.get("haiku")
+                updated = prior.get("updated")
+        except (json.JSONDecodeError, OSError):
+            pass
 
-    return {
+    if updated is None:
+        if site:
+            description = await _generate_description_for_today(events, site)
+        else:
+            # Legacy path: try to generate haiku without site context
+            try:
+                today_local = now_in_site_timezone_naive(site_tz)
+                today = today_local.date()
+                today_events = [e for e in events if e.date.date() == today]
+                if today_events:
+                    haiku_generator = HaikuGenerator()
+                    description = await haiku_generator.generate_haiku(
+                        today_local, today_events, max_retries=2
+                    )
+            except Exception as e:
+                logger.warning("Haiku generation failed: %s", e, exc_info=True)
+        updated = datetime.now(timezone.utc).isoformat()
+
+    web_data = {
         "events": web_events,
-        "updated": datetime.now(timezone.utc).isoformat(),
+        "updated": updated,
         "total_events": len(web_events),
         "site_name": site_name,
         "site_key": site_key,
@@ -253,6 +274,15 @@ async def generate_web_data(
         "errors": unique_error_messages,
         "haiku": description,
     }
+
+    if cache_path is not None:
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(json.dumps(web_data))
+        except OSError:
+            pass
+
+    return web_data
 
 
 async def deploy_to_web(


### PR DESCRIPTION
2 PRs - same goal. One simple, **This one mildly more complex**, but architecturally preferred. Only one is needed.

Goal: If after a parse the event data is the same do not regenerate or deploy the data.json file (i.e. no need to do so).

⏺ ## Summary                                                                                                                                          
                                                                                                                                                      
  Skip the Anthropic haiku API call on stable days by caching the last generated `web_data` per site and reusing the prior `haiku` / `updated` when   
  the freshly-scraped events match. Same byte-identical-output trick as PR #20, but the comparison happens inside `generate_web_data` (where the haiku
   is generated) instead of after the fact in `_deploy_with_github_auth`.                                                                             
                                                                                                                                                      
  ## Why                                                                                                                                              
                                                                                                                                                      
  The deploy bot was creating commits on every scheduled run because two volatile fields differed every time: `updated` (current timestamp) and       
  `haiku` (AI-generated, non-deterministic). PR #20 addressed the commit churn by reading the prior `data.json` after the clone and carrying those    
  fields forward, so the file landed byte-identical and the existing no-op short-circuit (`git diff --staged --quiet`) skipped the commit.            
                                                            
  That fixes the symptom but the haiku is still generated and discarded on every run. The fix has to live where the haiku is generated — inside       
  `generate_web_data`. That's what this PR does.
                                                                                                                                                      
  ## What this PR does                                      

  Inside `generate_web_data`:                                                                                                                         
   
  1. Look up the prior run's output at `.cache/around-the-grounds/<site_key>.json` (relative to cwd).                                                 
  2. If `prior["events"]` matches the freshly-built `web_events`, reuse `prior["haiku"]` and `prior["updated"]`. Skip the
  `_generate_description_for_today` / `HaikuGenerator` call entirely.                                                                                 
  3. Otherwise, generate the haiku as before and stamp a fresh `updated`.
  4. Write the resulting `web_data` back to the cache for next time.                                                                                  
                                                                                                                                                      
  All cache I/O is best-effort: `JSONDecodeError` and `OSError` are swallowed and the function falls back to the original generation path. Only the   
  site-aware path uses the cache; the legacy no-site path stays pure so unit tests don't accumulate hidden state across runs.                         
                                                                                                                                                      
  ## Why this design                                        

  - **Comparison lives next to the work it gates.** The haiku is generated in `generate_web_data`; that's where the decision to skip it belongs.      
  - **No new I/O beyond the local filesystem.** No `raw.githubusercontent.com` fetch, no extra clone, no GitHub-only assumption, no `deploy_subdir`
  path coupling.                                                                                                                                      
  - **No signature changes, no caller plumbing.** `deploy_to_web`, `preview_locally`, and the Temporal `generate_web_data` activity all keep working
  without modification. No tests needed updating.                                                                                                     
  - **One function changed.** ~40 line diff in `generate_web_data`, plus one line in `.gitignore`.
                                                                                                                                                      
  ## Compatibility                                          
                                                                                                                                                      
  - Cache directory is gitignored. First run on any environment misses the cache and regenerates — same behavior as today.                            
  - Persistent filesystems (the Ballard Temporal worker, local CLI runs) get the optimization. Ephemeral filesystems (Cloud Run Jobs) miss the cache
  every run, but the only haiku-generating site (`ballard-food-trucks`) runs on the persistent path. The Brooklyn sites set `generate_description:    
  false`, so they have nothing to cache and lose nothing.   
  - No callers need to change. `prior_data` isn't passed in from outside; the function manages its own state.                                         
                                                                                                                                                      
  ## Tradeoffs vs. PR #20
                                                                                                                                                      
  | | PR #20 | This PR |                                    
  |---|---|---|
  | Lines changed | +19 | ~+40 |                                                                                                                      
  | Skips no-op commit | ✅ | ✅ |
  | Skips haiku API call | ❌ | ✅ |                                                                                                                  
  | Where comparison lives | `_deploy_with_github_auth`, after the clone | `generate_web_data`, before haiku gen |
  | Source of "prior" | clone of target repo | local cache file |                                                                                     
  | Requires persistent FS | no | yes (for the optimization to kick in) |                                                                             
                                                                                                                                                      
  Both are minimal; this one trades a slightly larger diff for skipping the API call too, by moving the check upstream of where the work happens.     
                                                                                                                                                      
  ## Test plan                                                                                                                                        
                                                            
  - [x] Full test suite passes (493 tests, no new failures, no test changes needed)                                                                   
  - [ ] Manual: `--deploy` twice in a row with stable events → second run makes no Anthropic API call, no commit pushed
  - [ ] Manual: `--deploy` with an event change → fresh haiku generated, fresh `updated`, commit created, cache updated                               
  - [ ] Manual: delete `.cache/` → next `--deploy` regenerates fresh (graceful first-run behavior)  