### PR TITLE
Per-site skip_unchanged_deploys: skip no-op deploys without freezing Ballard's haiku

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,19 @@ tests/                             # Comprehensive test suite (499 tests)
 
 **Ballard-specific:** `config/sites/ballard-food-trucks.json` has `deploy_subdir: "public"` and `target_repo: "https://github.com/steveandroulakis/ballard-food-trucks.git"`. A Vercel project watches that repo's `public/` folder and redeploys on every push. The merge must preserve this behavior — changing `deploy_subdir` to `""` would destroy the target repo's structure on first deploy.
 
+### `skip_unchanged_deploys` (per-site no-op skip)
+
+`SiteConfig.skip_unchanged_deploys` (default `false`) makes a deploy a no-op when the new `events` array matches what is already deployed. The deploy carries the prior `data.json`'s volatile fields (`updated`, `haiku`) forward so the file stays byte-identical and the staged-diff short-circuit skips the commit/push. A real change to events — or to the template/CSS — still deploys.
+
+| Flag | Effect on deploy |
+|---|---|
+| `false` (default) | Every run deploys. `data.json` always differs because `updated` is regenerated (and, for sites that opt in, the haiku). Used by `ballard-food-trucks` so its **hourly weather haiku deploys every run** — see Haiku Generator below. |
+| `true` | No-op runs (events unchanged) skip the commit/push entirely. Used by `park-slope-music`, `childrens-events`. |
+
+**Root-mode interaction:** because the skip needs the prior `data.json` to diff against, enabling `skip_unchanged_deploys` on a **root-mode** site forces a `git clone` (with a fresh-`init` fallback for empty/new target repos) instead of the plain `git init`. Such sites therefore push **normally** (`git push HEAD:main`) and **accumulate history** rather than force-pushing a rewritten single commit each run. The `cloned ? normal-push : force-push` invariant in `_deploy_with_github_auth` keeps plain root mode (flag off) on the original force-push path.
+
+**Do not set `skip_unchanged_deploys: true` together with `generate_description: true`** unless you want the haiku frozen until the event set changes — the carry-forward would freeze it. Ballard deliberately keeps the flag off for this reason.
+
 ### Core Dependencies
 
 **Production:**

--- a/around_the_grounds/config/loader.py
+++ b/around_the_grounds/config/loader.py
@@ -37,6 +37,7 @@ def load_site_from_path(path: Path) -> SiteConfig:
         target_repo=data.get("target_repo", ""),
         generate_description=data.get("generate_description", True),
         deploy_subdir=data.get("deploy_subdir", ""),
+        skip_unchanged_deploys=data.get("skip_unchanged_deploys", False),
     )
 
 

--- a/around_the_grounds/config/sites/childrens-events.json
+++ b/around_the_grounds/config/sites/childrens-events.json
@@ -5,6 +5,7 @@
   "timezone": "America/New_York",
   "target_repo": "https://github.com/jredding/atg-childrens-events.git",
   "generate_description": false,
+  "skip_unchanged_deploys": true,
   "venues": [
     {
       "key": "macaroni-kid",

--- a/around_the_grounds/config/sites/park-slope-music.json
+++ b/around_the_grounds/config/sites/park-slope-music.json
@@ -5,6 +5,7 @@
   "timezone": "America/New_York",
   "target_repo": "https://github.com/jredding/atg-park-slope-music.git",
   "generate_description": false,
+  "skip_unchanged_deploys": true,
   "venues": [
     {
       "key": "union-hall",

--- a/around_the_grounds/main.py
+++ b/around_the_grounds/main.py
@@ -283,9 +283,14 @@ async def deploy_to_web(
             template_dir_name = "food-trucks"
 
         deploy_subdir = site.deploy_subdir if site else ""
+        skip_unchanged_deploys = site.skip_unchanged_deploys if site else False
 
         return _deploy_with_github_auth(
-            web_data, repository_url, template_dir_name, deploy_subdir
+            web_data,
+            repository_url,
+            template_dir_name,
+            deploy_subdir,
+            skip_unchanged_deploys,
         )
 
     except subprocess.CalledProcessError as e:
@@ -321,6 +326,7 @@ def _deploy_with_github_auth(
     repository_url: str,
     template_dir_name: str = "food-trucks",
     deploy_subdir: str = "",
+    skip_unchanged_deploys: bool = False,
 ) -> bool:
     """Deploy web data to git repository using GitHub App authentication.
 
@@ -332,6 +338,17 @@ def _deploy_with_github_auth(
       ``git add <subdir>/``, and a normal (non-force) push. Used when the
       target repo has other files at root that must be preserved (e.g. a
       Vercel project consuming ``public/``).
+
+    ``skip_unchanged_deploys`` (per-site opt-in) makes the deploy a no-op when
+    the new ``events`` array matches what is already deployed: the prior
+    data.json's volatile fields (``updated``, ``haiku``) are carried forward so
+    the file stays byte-identical and the staged-diff short-circuit skips the
+    commit/push. Because this needs the prior data.json to diff against, it
+    forces a clone even in root mode (with a fresh-init fallback for empty/new
+    target repos). Sites that want a fresh description every run (e.g. Ballard's
+    hourly weather haiku) leave this False so data.json always differs.
+
+    Invariant: ``cloned`` repos push normally; fresh-init repos force-push.
     """
     import shutil
     import tempfile
@@ -355,19 +372,15 @@ def _deploy_with_github_auth(
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_dir = Path(temp_dir) / "repo"
 
-            if deploy_subdir:
-                # Subdir mode: clone the existing repo so files outside the
-                # subdir (e.g. vercel.json, README.md) survive the update.
-                print(f"📥 Cloning {repository_url}...")
-                subprocess.run(
-                    ["git", "clone", authenticated_url, str(repo_dir)],
-                    check=True,
-                    capture_output=True,
-                )
-            else:
-                # Root mode: fresh init. Avoids clone failures on empty/new
-                # target repos; history gets rewritten by the force-push below.
-                repo_dir.mkdir()
+            # Clone when we need the existing repo contents: subdir mode (to
+            # preserve files outside the subdir) or skip_unchanged_deploys (to
+            # read the prior data.json and diff against it). Root mode without
+            # the skip flag uses a fresh init + force-push as before.
+            should_clone = bool(deploy_subdir) or skip_unchanged_deploys
+            cloned = False
+
+            def _init_repo() -> None:
+                repo_dir.mkdir(exist_ok=True)
                 subprocess.run(
                     ["git", "init"], cwd=repo_dir, check=True, capture_output=True
                 )
@@ -377,6 +390,30 @@ def _deploy_with_github_auth(
                     check=True,
                     capture_output=True,
                 )
+
+            if should_clone:
+                print(f"📥 Cloning {repository_url}...")
+                try:
+                    subprocess.run(
+                        ["git", "clone", authenticated_url, str(repo_dir)],
+                        check=True,
+                        capture_output=True,
+                    )
+                    cloned = True
+                except subprocess.CalledProcessError:
+                    if deploy_subdir:
+                        # Subdir mode requires an existing repo to preserve the
+                        # files at root; a clone failure is a real error.
+                        raise
+                    # Root mode + skip flag: the target repo is likely empty or
+                    # brand new. Fall back to a fresh init + force-push; there is
+                    # no prior data.json, so the first deploy proceeds normally.
+                    print("ℹ️  Clone failed; initializing fresh repo (first deploy)")
+                    _init_repo()
+            else:
+                # Root mode: fresh init. Avoids clone failures on empty/new
+                # target repos; history gets rewritten by the force-push below.
+                _init_repo()
 
             subprocess.run(
                 ["git", "config", "user.email", "bot@around-the-grounds.app"],
@@ -394,6 +431,29 @@ def _deploy_with_github_auth(
             shutil.copytree(public_templates_dir, target_public_dir, dirs_exist_ok=True)
 
             json_path = target_public_dir / "data.json"
+
+            # Work on a shallow copy so carrying volatile fields forward never
+            # mutates the dict the caller passed in (the CLI and Temporal both
+            # hand us a dict they may inspect after this call).
+            web_data = dict(web_data)
+
+            # Opt-in no-op skip: when the new events match what is already
+            # deployed, carry the prior data.json's volatile fields (`updated`,
+            # `haiku`) forward so the file stays byte-identical and the
+            # staged-diff short-circuit below skips the deploy. Only sites that
+            # set skip_unchanged_deploys reach this; sites wanting a fresh
+            # description every run (Ballard's hourly haiku) leave it off.
+            if skip_unchanged_deploys and cloned and json_path.exists():
+                try:
+                    with open(json_path) as f:
+                        prior = json.load(f)
+                    if prior.get("events") == web_data.get("events"):
+                        for volatile in ("updated", "haiku"):
+                            if volatile in prior:
+                                web_data[volatile] = prior[volatile]
+                except (json.JSONDecodeError, OSError):
+                    pass
+
             with open(json_path, "w") as f:
                 json.dump(web_data, f, indent=2)
 
@@ -405,8 +465,18 @@ def _deploy_with_github_auth(
                     ["git", "add", f"{deploy_subdir}/"],
                     cwd=repo_dir, check=True, capture_output=True,
                 )
-                # In subdir mode (clone), short-circuit no-op updates so the
-                # bot doesn't create empty commits when events haven't changed.
+            else:
+                subprocess.run(
+                    ["git", "add", "."],
+                    cwd=repo_dir, check=True, capture_output=True,
+                )
+
+            # Short-circuit no-op deploys when there is a prior commit to diff
+            # against. Cloned repos carry the existing data.json (subdir mode
+            # always clones; root mode clones only when skip_unchanged_deploys
+            # is set), so a byte-identical staged tree means nothing changed.
+            # Fresh-init root deploys have no baseline and always push.
+            if cloned:
                 diff_check = subprocess.run(
                     ["git", "diff", "--staged", "--quiet"],
                     cwd=repo_dir, capture_output=True,
@@ -414,11 +484,6 @@ def _deploy_with_github_auth(
                 if diff_check.returncode == 0:
                     print("ℹ️  No changes to deploy")
                     return True
-            else:
-                subprocess.run(
-                    ["git", "add", "."],
-                    cwd=repo_dir, check=True, capture_output=True,
-                )
 
             site_name = web_data.get("site_name", "Events")
             commit_msg = f"📅 Update {site_name} - {datetime.now().strftime('%Y-%m-%d %H:%M')}"
@@ -428,9 +493,11 @@ def _deploy_with_github_auth(
             )
 
             print(f"🚀 Pushing to {repository_url}...")
+            # Cloned repos push normally (on top of existing history); fresh-init
+            # root deploys force-push to (re)write the repo root.
             push_cmd = (
                 ["git", "push", "origin", "HEAD:main"]
-                if deploy_subdir
+                if cloned
                 else ["git", "push", "--force", "origin", "HEAD:main"]
             )
             subprocess.run(push_cmd, cwd=repo_dir, check=True, capture_output=True)

--- a/around_the_grounds/models/site.py
+++ b/around_the_grounds/models/site.py
@@ -20,3 +20,11 @@ class SiteConfig:
     # whose build output is scoped to a subfolder. The value also selects the
     # deploy strategy: empty → init + force-push, non-empty → clone + scoped add.
     deploy_subdir: str = ""
+    # When True, skip the deploy entirely if the new events array matches what is
+    # already deployed. The deploy carries the prior data.json's volatile fields
+    # (`updated`, `haiku`) forward so the file stays byte-identical and the no-op
+    # short-circuit fires. Enabling this also forces a clone in root mode (so the
+    # prior data.json is available to diff against). Sites that want a fresh
+    # description on every run (e.g. Ballard's hourly weather haiku) must leave
+    # this False — otherwise the haiku would be frozen until the event set changes.
+    skip_unchanged_deploys: bool = False

--- a/around_the_grounds/temporal/activities.py
+++ b/around_the_grounds/temporal/activities.py
@@ -68,6 +68,7 @@ class ScrapeActivities:
             "target_repo": site.target_repo,
             "generate_description": site.generate_description,
             "deploy_subdir": site.deploy_subdir,
+            "skip_unchanged_deploys": site.skip_unchanged_deploys,
             "venues": [
                 {
                     "key": v.key,
@@ -122,6 +123,7 @@ def _site_from_dict(site_dict: Dict[str, Any]) -> SiteConfig:
         target_repo=site_dict.get("target_repo", ""),
         generate_description=site_dict.get("generate_description", True),
         deploy_subdir=site_dict.get("deploy_subdir", ""),
+        skip_unchanged_deploys=site_dict.get("skip_unchanged_deploys", False),
     )
 
 
@@ -227,6 +229,7 @@ class DeploymentActivities:
                 site.target_repo,
                 site.template,
                 site.deploy_subdir,
+                site.skip_unchanged_deploys,
             )
 
             if success:

--- a/tests/integration/test_skip_unchanged_deploys.py
+++ b/tests/integration/test_skip_unchanged_deploys.py
@@ -1,0 +1,231 @@
+"""Integration tests for per-site ``skip_unchanged_deploys`` in the deploy path.
+
+These exercise the real git flow in ``_deploy_with_github_auth`` against a local
+bare repo standing in for the GitHub remote. GitHubAppAuth is faked and the
+hardcoded ``authenticated_url`` is rewritten to the local bare repo path, so no
+network or credentials are needed.
+
+The behaviors pinned here:
+
+- skip flag ON + unchanged events  -> volatile fields carried forward, deploy
+  is a byte-identical no-op (no new commit), in BOTH root and subdir modes.
+- skip flag ON + changed events     -> commit + push as normal.
+- skip flag ON + brand-new empty repo (root mode) -> first deploy proceeds.
+- skip flag OFF (Ballard)           -> never skips, even with identical events,
+  so the hourly haiku/timestamp always deploys.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+from around_the_grounds.main import _deploy_with_github_auth
+
+# The exact URL _deploy_with_github_auth builds from the faked auth below.
+AUTH_URL = "https://x-access-token:tok@github.com/owner/repo.git"
+REPO_URL = "https://github.com/owner/repo.git"
+
+
+def _make_bare_remote(tmp_path: Path) -> Path:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(remote)],
+        check=True,
+        capture_output=True,
+    )
+    return remote
+
+
+def _remote_head(remote: Path) -> Optional[str]:
+    out = subprocess.run(
+        ["git", "ls-remote", str(remote), "refs/heads/main"],
+        capture_output=True,
+        text=True,
+    )
+    return out.stdout.split()[0] if out.stdout.strip() else None
+
+
+def _remote_file(tmp_path: Path, remote: Path, rel_path: str) -> Optional[dict]:
+    co = tmp_path / "checkout"
+    if co.exists():
+        shutil.rmtree(co)
+    subprocess.run(
+        ["git", "clone", str(remote), str(co)], check=True, capture_output=True
+    )
+    f = co / rel_path
+    return json.loads(f.read_text()) if f.exists() else None
+
+
+def _run_deploy(
+    cwd: Path,
+    remote: Path,
+    web_data: dict,
+    template: str,
+    deploy_subdir: str,
+    skip: bool,
+) -> bool:
+    """Invoke _deploy_with_github_auth with auth faked and the remote redirected."""
+    real_run = subprocess.run
+
+    def fake_run(cmd: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(cmd, list):
+            cmd = [str(remote) if x == AUTH_URL else x for x in cmd]
+        return real_run(cmd, *args, **kwargs)
+
+    fake_auth = MagicMock()
+    fake_auth.get_access_token.return_value = "tok"
+    fake_auth.repo_owner = "owner"
+    fake_auth.repo_name = "repo"
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(cwd)
+        with patch(
+            "around_the_grounds.utils.github_auth.GitHubAppAuth",
+            return_value=fake_auth,
+        ), patch("around_the_grounds.main.subprocess.run", side_effect=fake_run):
+            return _deploy_with_github_auth(
+                web_data, REPO_URL, template, deploy_subdir, skip
+            )
+    finally:
+        os.chdir(original_cwd)
+
+
+def _make_cwd_with_template(tmp_path: Path, template: str) -> Path:
+    cwd = tmp_path / "workdir"
+    tdir = cwd / "public_templates" / template
+    tdir.mkdir(parents=True)
+    (tdir / "index.html").write_text("<html><body>template</body></html>")
+    return cwd
+
+
+def _web_data(
+    events: list, updated: str, haiku: Optional[str] = None
+) -> Dict[str, Any]:
+    return {
+        "events": events,
+        "updated": updated,
+        "total_events": len(events),
+        "site_name": "Test Site",
+        "site_key": "test",
+        "timezone": "America/New_York",
+        "timezone_label": "ET",
+        "timezone_note": "note",
+        "errors": [],
+        "haiku": haiku,
+    }
+
+
+E1 = [{"venue": "A", "title": "Show 1", "date": "2026-06-01"}]
+E2 = [{"venue": "A", "title": "Show 2", "date": "2026-06-02"}]
+
+
+OLD = "2026-05-01T00:00:00+00:00"
+NEW = "2026-05-30T12:00:00+00:00"
+
+
+class TestSkipUnchangedDeploys:
+    def test_root_mode_skip_on_unchanged_events_is_noop(self, tmp_path: Path) -> None:
+        """Root mode + skip + identical events -> no new commit (the key new capability)."""
+        remote = _make_bare_remote(tmp_path)
+        cwd = _make_cwd_with_template(tmp_path, "kids")
+        # Prior deploy seeds the remote exactly as production would (template +
+        # data.json) with an OLD timestamp.
+        _run_deploy(cwd, remote, _web_data(E1, OLD), "kids", "", skip=True)
+        head_before = _remote_head(remote)
+
+        # Same events, a fresh timestamp: must carry OLD forward and skip.
+        result = _run_deploy(cwd, remote, _web_data(E1, NEW), "kids", "", skip=True)
+
+        assert result is True
+        assert _remote_head(remote) == head_before, "no-op deploy must not add a commit"
+
+    def test_root_mode_skip_on_changed_events_deploys(self, tmp_path: Path) -> None:
+        """Root mode + skip + changed events -> commit + push."""
+        remote = _make_bare_remote(tmp_path)
+        cwd = _make_cwd_with_template(tmp_path, "kids")
+        _run_deploy(cwd, remote, _web_data(E1, OLD), "kids", "", skip=True)
+        head_before = _remote_head(remote)
+
+        result = _run_deploy(cwd, remote, _web_data(E2, NEW), "kids", "", skip=True)
+
+        assert result is True
+        assert _remote_head(remote) != head_before, "changed events must push a commit"
+        deployed = _remote_file(tmp_path, remote, "data.json")
+        assert deployed is not None and deployed["events"] == E2
+
+    def test_skip_still_deploys_template_change_with_unchanged_events(
+        self, tmp_path: Path
+    ) -> None:
+        """skip ON + same events but a changed template (index.html) -> still deploys.
+
+        The skip is meant to suppress only no-op runs; a real template/CSS change
+        must still go out even when the event set is identical.
+        """
+        remote = _make_bare_remote(tmp_path)
+        cwd = _make_cwd_with_template(tmp_path, "kids")
+        _run_deploy(cwd, remote, _web_data(E1, OLD), "kids", "", skip=True)
+        head_before = _remote_head(remote)
+
+        # Edit the template; events stay identical.
+        (cwd / "public_templates" / "kids" / "index.html").write_text(
+            "<html><body>NEW TEMPLATE</body></html>"
+        )
+        result = _run_deploy(cwd, remote, _web_data(E1, NEW), "kids", "", skip=True)
+
+        assert result is True
+        assert _remote_head(remote) != head_before, "template change must deploy"
+
+    def test_root_mode_skip_first_deploy_to_empty_repo(self, tmp_path: Path) -> None:
+        """Root mode + skip against an empty repo -> first deploy proceeds (no baseline)."""
+        remote = _make_bare_remote(tmp_path)  # empty: no main branch yet
+        assert _remote_head(remote) is None
+
+        cwd = _make_cwd_with_template(tmp_path, "kids")
+        result = _run_deploy(cwd, remote, _web_data(E1, NEW), "kids", "", skip=True)
+
+        assert result is True
+        deployed = _remote_file(tmp_path, remote, "data.json")
+        assert deployed is not None and deployed["events"] == E1
+
+    def test_subdir_mode_skip_on_unchanged_events_is_noop(self, tmp_path: Path) -> None:
+        """Subdir mode + skip + identical events -> no new commit."""
+        remote = _make_bare_remote(tmp_path)
+        cwd = _make_cwd_with_template(tmp_path, "food-trucks")
+        _run_deploy(cwd, remote, _web_data(E1, OLD), "food-trucks", "public", skip=True)
+        head_before = _remote_head(remote)
+
+        result = _run_deploy(
+            cwd, remote, _web_data(E1, NEW), "food-trucks", "public", skip=True
+        )
+
+        assert result is True
+        assert _remote_head(remote) == head_before, "no-op deploy must not add a commit"
+
+    def test_subdir_mode_skip_off_always_deploys(self, tmp_path: Path) -> None:
+        """Ballard case: skip OFF + identical events still deploys the fresh haiku/timestamp."""
+        remote = _make_bare_remote(tmp_path)
+        cwd = _make_cwd_with_template(tmp_path, "food-trucks")
+        _run_deploy(
+            cwd,
+            remote,
+            _web_data(E1, OLD, haiku="old haiku"),
+            "food-trucks",
+            "public",
+            skip=False,
+        )
+        head_before = _remote_head(remote)
+
+        new = _web_data(E1, NEW, haiku="fresh hourly haiku")
+        result = _run_deploy(cwd, remote, new, "food-trucks", "public", skip=False)
+
+        assert result is True
+        assert _remote_head(remote) != head_before, "skip OFF must always commit"
+        deployed = _remote_file(tmp_path, remote, "public/data.json")
+        assert deployed is not None
+        assert deployed["updated"] == NEW
+        assert deployed["haiku"] == "fresh hourly haiku"

--- a/tests/temporal/test_activities.py
+++ b/tests/temporal/test_activities.py
@@ -9,6 +9,7 @@ import pytest
 from around_the_grounds.temporal.activities import (
     DeploymentActivities,
     ScrapeActivities,
+    _site_from_dict,
 )
 
 
@@ -85,6 +86,7 @@ class TestScrapeActivities:
             target_repo="https://github.com/test/repo.git",
             generate_description=True,
             deploy_subdir="public",
+            skip_unchanged_deploys=True,
         )
 
         with patch(
@@ -102,6 +104,7 @@ class TestScrapeActivities:
         assert result["target_repo"] == "https://github.com/test/repo.git"
         assert result["generate_description"] is True
         assert result["deploy_subdir"] == "public"
+        assert result["skip_unchanged_deploys"] is True
         assert isinstance(result["venues"], list)
         assert result["venues"][0]["key"] == "stoup-ballard"
         assert result["venues"][0]["source_type"] == "html"
@@ -295,7 +298,25 @@ class TestDeploymentActivities:
             "https://github.com/steveandroulakis/ballard-food-trucks.git",
             "food-trucks",
             "public",
+            False,
         )
+
+    def test_site_from_dict_defaults_skip_unchanged_when_absent(self) -> None:
+        """Back-compat: an older payload without the flag defaults to False.
+
+        The persisted hourly schedule may send a site dict minted before this
+        field existed; it must not blow up or accidentally enable skipping.
+        """
+        legacy = {
+            "key": "ballard-food-trucks",
+            "name": "Food Trucks in Ballard",
+            "template": "food-trucks",
+            "timezone": "America/Los_Angeles",
+            "target_repo": "https://github.com/test/repo.git",
+            "deploy_subdir": "public",
+            "venues": [],
+        }
+        assert _site_from_dict(legacy).skip_unchanged_deploys is False
 
     @pytest.mark.asyncio
     async def test_deploy_to_git_raises_when_site_missing(self) -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -140,6 +140,7 @@ class TestSiteConfig:
         assert site.deploy_subdir == ""
         assert site.target_repo == ""
         assert site.generate_description is True
+        assert site.skip_unchanged_deploys is False
 
     def test_site_config_deploy_subdir(self) -> None:
         """deploy_subdir can be set explicitly for Vercel-style subfolder deploys."""
@@ -187,3 +188,20 @@ class TestSiteConfig:
         )
         site = load_site_from_path(config_path)
         assert site.deploy_subdir == ""
+
+    def test_loader_reads_skip_unchanged_deploys(self, tmp_path: Path) -> None:
+        """Loader pulls skip_unchanged_deploys out of JSON; defaults to False."""
+        base = {
+            "key": "loader-test",
+            "name": "Loader Test",
+            "template": "food-trucks",
+            "timezone": "America/Los_Angeles",
+            "venues": [],
+        }
+        on_path = tmp_path / "on.json"
+        on_path.write_text(json.dumps({**base, "skip_unchanged_deploys": True}))
+        assert load_site_from_path(on_path).skip_unchanged_deploys is True
+
+        off_path = tmp_path / "off.json"
+        off_path.write_text(json.dumps(base))
+        assert load_site_from_path(off_path).skip_unchanged_deploys is False


### PR DESCRIPTION
## Why

Alternative to #20 and #21. Both of those skip no-op deploys by **freezing the haiku** (carrying it forward / caching it). That breaks the Ballard food trucks site, where the haiku is **deliberately regenerated hourly and grounded in the current weather forecast** — those hourly runs aren't no-ops for Ballard, they carry fresh content.

The two goals are per-site preferences, not one global behavior:
- **jredding's sites** want no-op deploys skipped (no haiku — `generate_description: false`).
- **Ballard** wants the hourly weather haiku deployed regardless.

This PR makes them coexist with an orthogonal per-site flag instead of changing behavior globally.

## What

Adds `SiteConfig.skip_unchanged_deploys` (default `false`):

- **`false` (Ballard):** no carry-forward → `data.json` always differs (`updated` + fresh haiku) → deploys every run. `generate_web_data` is **unchanged** — the haiku is still generated, no API call is skipped, nothing is cached.
- **`true` (jredding's `park-slope-music`, `childrens-events`):** when the new `events` array matches what's deployed, the prior `data.json`'s volatile fields (`updated`, `haiku`) are carried forward so the file is byte-identical and the existing staged-diff short-circuit skips the commit/push. A real change to **events or the template/CSS** still deploys.

### Root-mode fix (the part #20/#21 didn't deliver)

The no-op short-circuit previously only existed in **subdir mode**. jredding's sites are **root mode** (`git init` fresh + force-push every run), so neither earlier PR actually skipped deploys for them. Here, enabling the flag forces a `git clone` (with a fresh-`init` fallback for empty/new repos) so root-mode sites have a baseline to diff against.

Invariant: `cloned ? normal-push : force-push`. Plain root mode (flag off) keeps the original `init` + force-push path; skip-enabled root sites clone + normal-push and therefore **accumulate history** instead of rewriting to a single commit (documented in `CLAUDE.md`).

## Behavior matrix

| Run-over-run change | skip off (Ballard) | skip on (jredding) |
|---|---|---|
| Events changed | deploy | deploy |
| Events identical, only `updated`/haiku differ | **deploy** (fresh haiku) | **no-op, skipped** |
| Template/CSS changed | deploy | deploy |
| Prior `data.json` missing/malformed | deploy fresh | deploy fresh |

## Tests

New real-git integration tests (`tests/integration/test_skip_unchanged_deploys.py`) against a local bare remote covering: root-mode no-op skip, root-mode changed-events deploy, template-change-still-deploys, empty-repo first deploy, and subdir skip-off-always-deploys (the Ballard guarantee). Plus config-loader and Temporal round-trip/back-compat unit tests.

Full suite: **501 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)