### PR TITLE
Fix Chuck's Greenwood parser showing #VALUE! spreadsheet errors

### DIFF
--- a/around_the_grounds/parsers/chucks_greenwood.py
+++ b/around_the_grounds/parsers/chucks_greenwood.py
@@ -24,6 +24,23 @@ from .base import BaseParser
 class ChucksGreenwoodParser(BaseParser):
     """Parser for Chuck's Hop Shop Greenwood food truck schedule."""
 
+    # Google Sheets formula error tokens that can appear in the source
+    # spreadsheet's cells (e.g. when a lookup formula fails). These must never
+    # be treated as vendor names. Compared case-insensitively.
+    SPREADSHEET_ERROR_VALUES = frozenset(
+        {
+            "#value!",
+            "#ref!",
+            "#n/a",
+            "#name?",
+            "#div/0!",
+            "#null!",
+            "#num!",
+            "#error!",
+            "#getting_data",
+        }
+    )
+
     # Month abbreviation to number mapping
     MONTH_MAP = {
         "Jan": 1,
@@ -175,9 +192,18 @@ class ChucksGreenwoodParser(BaseParser):
             extraction_method="html",
         )
 
+    def _is_spreadsheet_error(self, value: str) -> bool:
+        """Return True if a value is a Google Sheets formula error token."""
+        return value.strip().lower() in self.SPREADSHEET_ERROR_VALUES
+
     def _extract_vendor_name(self, event_name: str) -> Optional[str]:
         """Extract vendor name from event name, handling meal type prefixes."""
         if not event_name or not event_name.strip():
+            return None
+
+        # Reject spreadsheet formula errors (e.g. "#VALUE!") that leak in from
+        # the source Google Sheet — these are not real vendor names.
+        if self._is_spreadsheet_error(event_name):
             return None
 
         # Handle format like "Dinner: T'Juana" or "Brunch: Good Morning Tacos"
@@ -189,7 +215,9 @@ class ChucksGreenwoodParser(BaseParser):
 
                 # Validate meal type
                 if meal_type.lower() in ["brunch", "dinner"]:
-                    return vendor_name if vendor_name else None
+                    if not vendor_name or self._is_spreadsheet_error(vendor_name):
+                        return None
+                    return vendor_name
                 else:
                     # If not a recognized meal type, treat whole string as vendor name
                     cleaned_name = event_name.strip()

--- a/tests/parsers/test_chucks_greenwood.py
+++ b/tests/parsers/test_chucks_greenwood.py
@@ -63,8 +63,7 @@ class TestChucksGreenwoodParser:
                 assert len(events) > 0
                 assert all(event.venue_key == "chucks-greenwood" for event in events)
                 assert all(
-                    event.venue_name == "Chuck's Hop Shop Greenwood"
-                    for event in events
+                    event.venue_name == "Chuck's Hop Shop Greenwood" for event in events
                 )
                 assert all(event.title.strip() != "" for event in events)
                 assert all(event.date is not None for event in events)
@@ -226,6 +225,22 @@ Another,incomplete"""
         result = parser._extract_vendor_name("   ")
         assert result is None
 
+    def test_extract_vendor_name_spreadsheet_error_value(
+        self, parser: ChucksGreenwoodParser
+    ) -> None:
+        """Spreadsheet formula errors must not be treated as vendor names."""
+        assert parser._extract_vendor_name("#VALUE!") is None
+        assert parser._extract_vendor_name("#REF!") is None
+        assert parser._extract_vendor_name("#N/A") is None
+        # Case-insensitive and whitespace-tolerant
+        assert parser._extract_vendor_name("  #value!  ") is None
+
+    def test_extract_vendor_name_error_value_after_prefix(
+        self, parser: ChucksGreenwoodParser
+    ) -> None:
+        """A meal prefix followed by a spreadsheet error yields no vendor."""
+        assert parser._extract_vendor_name("Dinner: #VALUE!") is None
+
     # DATE PARSING TESTS
 
     @freeze_time("2025-08-05")
@@ -369,6 +384,27 @@ Another,incomplete"""
         result = parser._parse_csv_row(row)
         assert result is None
 
+    def test_parse_csv_row_spreadsheet_error_name(
+        self, parser: ChucksGreenwoodParser
+    ) -> None:
+        """A food truck row whose name is a spreadsheet error is skipped."""
+        row = [
+            "Fri",
+            "Aug 1",
+            "12 AM",
+            "to",
+            "Sat",
+            "Food Truck",
+            "#VALUE!",
+            "Wed",
+            "Tue",
+            "FALSE",
+            "TRUE",
+        ]
+
+        result = parser._parse_csv_row(row)
+        assert result is None
+
     def test_parse_csv_row_invalid_date(self, parser: ChucksGreenwoodParser) -> None:
         """Test parsing a row with invalid date."""
         row = [
@@ -454,6 +490,35 @@ Tue,Aug 5,12 AM,to,Tue,Food Truck,Tat's Deli,Wed,Tue,FALSE,TRUE"""
                 for event in events:
                     assert "Trivia" not in event.title
                     assert "Bingo" not in event.title
+
+    @pytest.mark.asyncio
+    @freeze_time("2025-08-05")
+    async def test_parse_skips_spreadsheet_error_rows(
+        self, parser: ChucksGreenwoodParser
+    ) -> None:
+        """Rows with #VALUE! source errors are skipped, real vendors kept.
+
+        Mirrors the real Google Sheet, where near-term food-truck rows carry a
+        #VALUE! formula error while later rows have real vendor names.
+        """
+        csv_with_errors = """Greenwood Events & Food Trucks,,,,,,,Date Created,Last Updated,All Day Event,Recurring Event
+Fri,Aug 1,12 AM,to,Sat,Food Truck,#VALUE!,Fri,Fri,FALSE,TRUE
+Sat,Aug 2,12 AM,to,Sat,Food Truck,#VALUE!,Sat,Fri,FALSE,TRUE
+Sun,Aug 16,12 AM,to,Sat,Food Truck,Dinner: Georgia's Greek,Sat,Fri,FALSE,TRUE
+Mon,Aug 17,12 AM,to,Sat,Food Truck,Dinner: Off the Rez,Sun,Wed,FALSE,TRUE"""
+
+        with aioresponses() as m:
+            m.get(parser.venue.url, status=200, body=csv_with_errors)
+
+            async with aiohttp.ClientSession() as session:
+                events = await parser.parse(session)
+
+                # Only the two real vendors survive; #VALUE! rows are dropped.
+                assert len(events) == 2
+                event_names = [event.title for event in events]
+                assert "Georgia's Greek" in event_names
+                assert "Off the Rez" in event_names
+                assert all("#VALUE!" not in name for name in event_names)
 
     @pytest.mark.asyncio
     @freeze_time("2025-12-15")  # Test year rollover scenario


### PR DESCRIPTION
## Problem

On ballardfoodtrucks.com, Chuck's Hop Shop Greenwood was showing database `#VALUE!` entries instead of food-truck names.

Chuck's schedule is sourced from a published Google Sheet (CSV export). The event-name column currently contains the literal token `#VALUE!` — a Google Sheets *formula error* — for the near-term rows (32 of them as of writing), because the sheet's own lookup formulas are erroring out. Real vendor names only appear further out. The parser read that error token straight through as the event title, so the site displayed `#VALUE!` instead of a vendor name.

## Fix

In `around_the_grounds/parsers/chucks_greenwood.py`:

- Added a `SPREADSHEET_ERROR_VALUES` set of Google Sheets error tokens (`#VALUE!`, `#REF!`, `#N/A`, `#DIV/0!`, `#NAME?`, `#NULL!`, `#NUM!`, `#ERROR!`, `#GETTING_DATA`).
- `_extract_vendor_name` now rejects those tokens (case-insensitive, whitespace-tolerant), both as a bare value and after a meal-type prefix (e.g. `"Dinner: #VALUE!"`). When it returns `None`, the row is skipped — exactly like an empty event name.

Rows with genuine vendor names are unaffected.

## Testing

- Added 4 tests in `tests/parsers/test_chucks_greenwood.py`: unit coverage for error-token extraction (bare, prefixed, case/whitespace variants), a CSV-row skip test, and an integration test mirroring the real sheet (error rows mixed with real vendors). All 36 Chuck's tests pass.
- Verified against the **live CSV**: 22 events, zero `#VALUE!` titles remaining, all real vendor names.
- black / isort / mypy clean on the changed files.

Note: the full suite has 4 pre-existing failures in `test_haiku_integration.py` / `test_coordinator.py` that also fail on a clean tree (date-sensitive tests reacting to the current date); they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Fj59SUumWUY6JrMgiwcTu

---
_Generated by [Claude Code](https://claude.ai/code/session_018Fj59SUumWUY6JrMgiwcTu)_